### PR TITLE
[30] Style fixes to spacing and text description

### DIFF
--- a/styles.css
+++ b/styles.css
@@ -52,7 +52,7 @@
 	display: flex;
 	align-items: center;
 	justify-content: flex-start;
-	padding: 0px 5px;
+	padding: 5px 5px;
 }
 
 .googleTaskDoneContainer {
@@ -82,7 +82,8 @@
 }
 
 .googleTaskDetails {
-	font-size: 0.5em;
+	font-size: 0.75em;
+	color: #aaa6a6;
 }
 
 .googleTaskForceShow {


### PR DESCRIPTION
The description of the tasks were a bit difficult to read - then enlargens the text at `.15em`. I also added `5px` to the spacing between the tasks since they were a bit close together.

##  FIXES
#30 

## CHANGES
- `5px` between tasks
- Task description now `.75em` (before `.5em`)

**BEFORE**
![Screenshot 2023-10-30 at 10 46 13 AM](https://github.com/YukiGasai/obsidian-google-tasks/assets/5641096/0b990fbd-e982-408a-bbe1-cb4c616e534c)


**AFTER**
![Screenshot 2023-10-30 at 10 46 13 AM](https://github.com/YukiGasai/obsidian-google-tasks/assets/5641096/be746de3-5b0c-4fef-9cfd-d066b325cbda)

