### PR TITLE
Preserve newline characters in task details

### DIFF
--- a/src/modal/CreateTaskModal.ts
+++ b/src/modal/CreateTaskModal.ts
@@ -38,11 +38,13 @@ export class CreateTaskModal extends Modal {
 			.settingEl.querySelector("input")
 			.focus();
 
-		new Setting(contentEl).setName("Details").addText((text) =>
+		new Setting(contentEl).setName("Details").addTextArea((text) => {
 			text.onChange((value) => {
 				this.taskDetails = value;
-			})
-		);
+			});
+			text.inputEl.rows = 4;
+			text.inputEl.style.resize = "none";
+		});
 
 		const dateSelectElement = customSetting(
 			contentEl,

--- a/src/modal/UpdateTaskModal.ts
+++ b/src/modal/UpdateTaskModal.ts
@@ -34,13 +34,15 @@ export class UpdateTaskModal extends Modal {
 				});
 				text.setValue(this.newTask.title);
 				text.inputEl.focus();
-			});
+		});
 
-		new Setting(contentEl).setName("Details").addText((text) => {
+		new Setting(contentEl).setName("Details").addTextArea((text) => {
 			text.onChange((value) => {
 				this.newTask.notes = value;
 			});
 			text.setValue(this.newTask.notes);
+			text.inputEl.rows = 4;
+			text.inputEl.style.resize = "none";
 		});
 
 		const dateSelectElement = customSetting(


### PR DESCRIPTION
Fixed to display details in a text area because line break codes would be lost in a text box. #48 

before
![image](https://github.com/user-attachments/assets/0d0a2854-8be5-4bc4-b2d5-4fdb98bd196a)

after
![image](https://github.com/user-attachments/assets/776166e5-b288-438f-8f96-189ee58e98a3)
