### PR TITLE
Add functionality to create Obsidian notes from Google Tasks.

### DIFF
--- a/src/GoogleTasksPlugin.ts
+++ b/src/GoogleTasksPlugin.ts
@@ -1,5 +1,8 @@
+import { CreateTaskNoteModal } from "./modal/CreateTaskNoteModal";
+import { TaskSelectionModal } from "./modal/TaskSelectionModal";
 import { getRT } from './helper/LocalStorage';
 import { Editor, MarkdownView, Plugin, WorkspaceLeaf, moment, Notice, TFile } from "obsidian";
+import type { Task } from "./helper/types";
 import type { GoogleTasksSettings } from "./helper/types";
 import { getAllUncompletedTasksOrderdByDue, getOneTaskById } from "./googleApi/ListAllTasks";
 import {
@@ -89,7 +92,16 @@ export default class GoogleTasks extends Plugin {
 			}
 		})
 	}
+	// Add this method to the GoogleTasks class
 
+	async selectTaskAndCreateNote() {
+		const tasks = await getAllUncompletedTasksOrderdByDue(this);
+
+		// Reuse the existing TaskListModal pattern but with custom callback
+		new TaskSelectionModal(this, tasks, (task: Task) => {
+			new CreateTaskNoteModal(this, task).open();
+		}).open();
+	}
 	async onload() {
 		await this.loadSettings();
 		this.plugin = this;
@@ -253,6 +265,25 @@ export default class GoogleTasks extends Plugin {
 			},
 		});
 
+		// Create note from task command
+		this.addCommand({
+			id: "create-note-from-google-task",
+			name: "Create Note from Google Task",
+			checkCallback: (checking: boolean) => {
+				const canRun = settingsAreCompleteAndLoggedIn(this, false);
+
+				if (checking) {
+					return canRun;
+				}
+
+				if (!canRun) {
+					return;
+				}
+
+				// Show task selection modal, then create note modal
+				// this.selectTaskAndCreateNote();
+			},
+		});
 
 		//Copy Refresh token to clipboard
 		this.addCommand({

--- a/src/helper/CreateTaskNote.ts
+++ b/src/helper/CreateTaskNote.ts
@@ -1,0 +1,131 @@
+import { Notice, TFile, TFolder, normalizePath } from "obsidian";
+import type GoogleTasks from "../GoogleTasksPlugin";
+import type { Task } from "./types";
+
+export interface CreateNoteResult {
+	file: TFile | null;
+	exists: boolean;
+	suggestedPath: string;
+}
+
+export async function checkIfNoteExists(
+	plugin: GoogleTasks,
+	task: Task,
+	folderPath: string = ""
+): Promise<{ exists: boolean; existingFile: TFile | null; basePath: string; nextAvailablePath: string }> {
+	const vault = plugin.app.vault;
+	const sanitizedTitle = sanitizeFileName(task.title);
+	
+	const basePath = folderPath
+		? normalizePath(`${folderPath}/${sanitizedTitle}.md`)
+		: normalizePath(`${sanitizedTitle}.md`);
+	
+	const existingFile = vault.getAbstractFileByPath(basePath);
+	
+	if (!existingFile) {
+		return { exists: false, existingFile: null, basePath, nextAvailablePath: basePath };
+	}
+	
+	// Find next available number
+	let counter = 1;
+	let nextPath: string;
+	
+	do {
+		nextPath = folderPath
+			? normalizePath(`${folderPath}/${sanitizedTitle} (${counter}).md`)
+			: normalizePath(`${sanitizedTitle} (${counter}).md`);
+		counter++;
+	} while (vault.getAbstractFileByPath(nextPath));
+	
+	return { 
+		exists: true, 
+		existingFile: existingFile as TFile, 
+		basePath, 
+		nextAvailablePath: nextPath 
+	};
+}
+
+export function sanitizeFileName(title: string): string {
+	return title
+		.replace(/[\\/:*?"<>|]/g, "-")
+		.replace(/\s+/g, " ")
+		.trim()
+		.substring(0, 100);
+}
+
+export async function createTaskNote(
+	plugin: GoogleTasks,
+	task: Task,
+	folderPath: string = "",
+	forcePath: string | null = null  // Allow forcing a specific path
+): Promise<TFile | null> {
+	const vault = plugin.app.vault;
+
+	// Use forced path or generate from task title
+	const fullPath = forcePath || (folderPath
+		? normalizePath(`${folderPath}/${sanitizeFileName(task.title)}.md`)
+		: normalizePath(`${sanitizeFileName(task.title)}.md`));
+
+	// Generate the markdown content
+	const content = generateTaskMarkdown(task);
+
+	try {
+		// Ensure the folder exists (and is actually a folder, not a file)
+		if (folderPath) {
+			const normalizedFolder = normalizePath(folderPath);
+			const existingItem = vault.getAbstractFileByPath(normalizedFolder);
+			
+			if (existingItem) {
+				if (!(existingItem instanceof TFolder)) {
+					new Notice(`Cannot create folder "${folderPath}" - a file with that name already exists`);
+					return null;
+				}
+			} else {
+				await vault.createFolder(normalizedFolder);
+			}
+		}
+
+		// Create the file
+		const file = await vault.create(fullPath, content);
+		new Notice(`Created note: ${file.name}`);
+		return file;
+	} catch (error) {
+		console.error("Error creating task note:", error);
+		new Notice(`Failed to create note: ${error.message}`);
+		return null;
+	}
+}
+
+/**
+ * Generates markdown content from a Task object
+ */
+function generateTaskMarkdown(task: Task): string {
+	const lines: string[] = [];
+
+	// YAML frontmatter
+	lines.push("---");
+	if (task.taskListName) {
+		lines.push(`task-list: "${task.taskListName}"`);
+	}
+	if (task.due) {
+		lines.push(`due: ${window.moment.utc(task.due).local().format("YYYY-MM-DD")}`);
+	}
+	lines.push("tags:");
+	lines.push("  - google-tasks");
+	lines.push("---");
+	lines.push("");
+
+	// Title as H1
+	lines.push(`# ${task.title}`);
+	lines.push("");
+
+	// Notes section
+	if (task.notes) {
+		lines.push("## Notes");
+		lines.push("");
+		lines.push(task.notes);
+		lines.push("");
+	}
+
+	return lines.join("\n");
+}

--- a/src/modal/CreateTaskNoteModal.ts
+++ b/src/modal/CreateTaskNoteModal.ts
@@ -1,0 +1,191 @@
+import { Modal, Setting, Notice } from "obsidian";
+import type GoogleTasks from "../GoogleTasksPlugin";
+import type { Task } from "../helper/types";
+import { createTaskNote, checkIfNoteExists } from "../helper/CreateTaskNote";
+
+const DEFAULT_FOLDER = "Tasks";
+
+export class CreateTaskNoteModal extends Modal {
+    plugin: GoogleTasks;
+    task: Task;
+    folderPath: string = DEFAULT_FOLDER;
+    openAfterCreate: boolean = true;
+
+    constructor(plugin: GoogleTasks, task: Task) {
+        super(plugin.app);
+        this.plugin = plugin;
+        this.task = task;
+    }
+
+    async onOpen() {
+        const { contentEl } = this;
+
+        contentEl.createEl("h1", { text: "Create Note from Task" });
+
+        // Show task preview
+        contentEl.createEl("h3", { text: this.task.title });
+        
+        if (this.task.notes) {
+            contentEl.createEl("p", { 
+                text: this.task.notes,
+                cls: "task-note-preview" 
+            });
+        }
+
+        // Folder path setting
+        new Setting(contentEl)
+            .setName("Folder")
+            .setDesc(`Leave empty for default "/${DEFAULT_FOLDER}" folder`)
+            .addText((text) => {
+                text.setPlaceholder(DEFAULT_FOLDER);
+                text.setValue(DEFAULT_FOLDER);
+                text.onChange((value) => {
+                    // If empty, use default
+                    this.folderPath = value.trim() || DEFAULT_FOLDER;
+                });
+            });
+
+        // Open after create setting
+        new Setting(contentEl)
+            .setName("Open note after creation")
+            .addToggle((toggle) => {
+                toggle.setValue(true);
+                toggle.onChange((value) => {
+                    this.openAfterCreate = value;
+                });
+            });
+
+        // Create button
+        new Setting(contentEl)
+            .addButton((button) => {
+                button
+                    .setButtonText("Create Note")
+                    .setCta()
+                    .onClick(async () => {
+                        await this.handleCreateNote();
+                    });
+            });
+    }
+
+    async handleCreateNote() {
+        // Check if file already exists
+        const check = await checkIfNoteExists(this.plugin, this.task, this.folderPath);
+        
+        if (check.exists) {
+            // Show confirmation modal
+            new DuplicateFileModal(
+                this.plugin,
+                this.task,
+                this.folderPath,
+                check.nextAvailablePath,
+                this.openAfterCreate,
+                () => this.close()
+            ).open();
+        } else {
+            // Create directly
+            const file = await createTaskNote(this.plugin, this.task, this.folderPath);
+            
+            if (file && this.openAfterCreate) {
+                await this.plugin.app.workspace.getLeaf().openFile(file);
+            }
+            
+            this.close();
+        }
+    }
+
+    onClose() {
+        const { contentEl } = this;
+        contentEl.empty();
+    }
+}
+
+/**
+ * Modal shown when a file with the same name already exists
+ */
+class DuplicateFileModal extends Modal {
+    plugin: GoogleTasks;
+    task: Task;
+    folderPath: string;
+    nextAvailablePath: string;
+    openAfterCreate: boolean;
+    onComplete: () => void;
+
+    constructor(
+        plugin: GoogleTasks,
+        task: Task,
+        folderPath: string,
+        nextAvailablePath: string,
+        openAfterCreate: boolean,
+        onComplete: () => void
+    ) {
+        super(plugin.app);
+        this.plugin = plugin;
+        this.task = task;
+        this.folderPath = folderPath;
+        this.nextAvailablePath = nextAvailablePath;
+        this.openAfterCreate = openAfterCreate;
+        this.onComplete = onComplete;
+    }
+
+    onOpen() {
+        const { contentEl } = this;
+
+        contentEl.createEl("h2", { text: "File Already Exists" });
+        
+        contentEl.createEl("p", { 
+            text: `A note with this name already exists in the folder.` 
+        });
+        
+        contentEl.createEl("p", { 
+            text: `Would you like to create it as:`,
+            cls: "task-note-preview"
+        });
+
+        // Show the suggested new name
+        const fileName = this.nextAvailablePath.split("/").pop();
+        contentEl.createEl("p", { 
+            text: `"${fileName}"`,
+            cls: "duplicate-file-suggestion"
+        });
+
+        const buttonContainer = contentEl.createDiv({ cls: "duplicate-file-buttons" });
+
+        // Cancel button
+        new Setting(buttonContainer)
+            .addButton((button) => {
+                button
+                    .setButtonText("Cancel")
+                    .onClick(() => {
+                        this.close();
+                    });
+            });
+
+        // Create with new name button
+        new Setting(buttonContainer)
+            .addButton((button) => {
+                button
+                    .setButtonText("Create with New Name")
+                    .setCta()
+                    .onClick(async () => {
+                        const file = await createTaskNote(
+                            this.plugin,
+                            this.task,
+                            this.folderPath,
+                            this.nextAvailablePath
+                        );
+                        
+                        if (file && this.openAfterCreate) {
+                            await this.plugin.app.workspace.getLeaf().openFile(file);
+                        }
+                        
+                        this.close();
+                        this.onComplete();
+                    });
+            });
+    }
+
+    onClose() {
+        const { contentEl } = this;
+        contentEl.empty();
+    }
+}

--- a/src/modal/TaskSelectionModal.ts
+++ b/src/modal/TaskSelectionModal.ts
@@ -1,0 +1,37 @@
+import { App, FuzzySuggestModal } from "obsidian";
+import type GoogleTasks from "../GoogleTasksPlugin";
+import type { Task } from "../helper/types";
+
+export class TaskSelectionModal extends FuzzySuggestModal<Task> {
+	plugin: GoogleTasks;
+	tasks: Task[];
+	onSelect: (task: Task) => void;
+
+	constructor(plugin: GoogleTasks, tasks: Task[], onSelect: (task: Task) => void) {
+		super(plugin.app);
+		this.plugin = plugin;
+		this.tasks = tasks;
+		this.onSelect = onSelect;
+		this.setPlaceholder("Select a task to create a note from...");
+	}
+
+	getItems(): Task[] {
+		return this.tasks;
+	}
+
+	getItemText(task: Task): string {
+		let text = task.title;
+		if (task.due) {
+			const dueDate = window.moment.utc(task.due).local().format("YYYY-MM-DD");
+			text += ` (${dueDate})`;
+		}
+		if (task.taskListName) {
+			text += ` [${task.taskListName}]`;
+		}
+		return text;
+	}
+
+	onChooseItem(task: Task, evt: MouseEvent | KeyboardEvent): void {
+		this.onSelect(task);
+	}
+}

--- a/src/view/GoogleTaskView.ts
+++ b/src/view/GoogleTaskView.ts
@@ -9,6 +9,7 @@ import {
 import TreeMap from "ts-treemap";
 import { ConfirmationModal } from "../modal/ConfirmationModal";
 import { CreateTaskModal } from "../modal/CreateTaskModal";
+import { CreateTaskNoteModal } from "../modal/CreateTaskNoteModal";
 import {
 	GoogleCompleteTask,
 	GoogleUnCompleteTask,
@@ -152,10 +153,22 @@ createTaskElement(task:Task, containerEl: HTMLElement, isUnDoneList: boolean, is
 		});
 	}
 
+	// Add "Create Note" button ONLY for uncompleted tasks
+	if (isUnDoneList && !isSubTaskList) {
+		const createNoteButton = new ButtonComponent(taskContainer);
+		createNoteButton.setClass("googleTaskCreateNote");
+		createNoteButton.setIcon("file-plus");
+		createNoteButton.setTooltip("Create note from task");
+		createNoteButton.onClick((event) => {
+			event.stopPropagation();
+			new CreateTaskNoteModal(this.plugin, task).open();
+		});
+	}
+
 	const checkBox = taskContainer.createEl("input", {
 		type: "checkbox",
 	});
-	if (!isUnDoneList || (isSubTaskList && task.completed) ) {
+	if (!isUnDoneList || (isSubTaskList && task.completed)) {
 		checkBox.checked = true;
 	}
 	checkBox.addEventListener("click", async (event) => {

--- a/styles.css
+++ b/styles.css
@@ -4,6 +4,7 @@
 	align-items: flex-start;
 	justify-content: flex-start;
 	padding-left: 10px;
+	container-type: inline-size;
 }
 
 .googleTaskAddButton {
@@ -45,7 +46,73 @@
 	display: flex;
 	flex-direction: row;
 	justify-content: space-between;
+	align-items: center;
 	padding-right: 20px;
+	gap: 8px;
+}
+
+/* Fix setting-item padding in title container (applies in both layouts) */
+.googleTaskTitleContainer > .setting-item {
+	border: none;
+	padding: 0;
+	margin: 0;
+}
+
+.googleTaskTitleContainer > .setting-item > .setting-item-info {
+	display: none;
+}
+
+@container (max-width: 355px) {
+	.googleTaskTitleContainer {
+		flex-direction: column;
+		align-items: stretch;
+		padding-right: 5px;
+		gap: 8px;
+	}
+	
+	.googleTaskTitleContainer > h4 {
+		text-align: center;
+		order: 1;
+		margin: 0;
+	}
+	
+	/* Fix the + button container */
+	.googleTaskTitleContainer > .setting-item:first-of-type {
+		order: 2;
+		display: flex;
+		justify-content: center;
+		width: auto;
+		align-self: center;
+	}
+	
+	/* Keep the button circular */
+	.googleTaskTitleContainer > .setting-item:first-of-type .googleTaskAddButton {
+		width: 30px !important;
+		height: 30px !important;
+		min-width: 30px;
+		max-width: 30px;
+		border-radius: 50%;
+	}
+	
+	.googleTaskTitleContainer > .setting-item:first-of-type > .setting-item-control {
+		width: auto;
+		justify-content: center;
+	}
+	
+	/* Style the dropdown container */
+	.googleTaskTitleContainer > .setting-item:last-of-type {
+		order: 3;
+		width: 100%;
+	}
+	
+	.googleTaskTitleContainer > .setting-item:last-of-type > .setting-item-control {
+		width: 100%;
+		justify-content: center;
+	}
+	
+	.googleTaskTitleContainer > .setting-item:last-of-type > .setting-item-control > select {
+		width: 100%;
+	}
 }
 
 .googleTaskContainer {
@@ -102,6 +169,34 @@
 
 .googleTaskTrash:hover > * {
 	color: red;
+}
+
+/* Create Note Button */
+.googleTaskCreateNote {
+    background: transparent;
+    border: none;
+    cursor: pointer;
+    padding: 2px 4px;
+    margin-right: 4px;
+    opacity: 0.6;
+    transition: opacity 0.2s;
+}
+
+.googleTaskCreateNote:hover {
+    opacity: 1;
+}
+
+.googleTaskContainer:hover .googleTaskCreateNote {
+    opacity: 0.8;
+}
+
+.task-note-preview {
+    color: var(--text-muted);
+    font-size: 0.9em;
+    margin-bottom: 1em;
+    padding: 0.5em;
+    background: var(--background-secondary);
+    border-radius: 4px;
 }
 
 .googleSubTaskContainer{


### PR DESCRIPTION
## Description
### Summary
This adds a new feature that allows users to create Obsidian markdown notes directly from their Google Tasks. This is useful for users who want to expand on a task, add more context, or create a dedicated workspace for a specific task.
### Features Added
- **Create Note Button**: Added a new button (📄 icon) next to each uncompleted task in the sidebar view
- **Create Note Modal**: A modal dialog that allows users to:
    - Preview the task title and notes before creating
    - Choose a custom folder path (defaults to `/Tasks`)
    - Toggle whether to open the note after creation

- **Smart File Naming**:
    - Automatically sanitizes task titles for valid filenames
    - Detects duplicate files and offers to create with sequential numbering (e.g., `Task (1).md`, `Task (2).md`)

- **Auto Folder Creation**: Creates the target folder if it doesn't exist
- **Responsive Sidebar**: Improved CSS for the title container that adapts when the sidebar is collapsed (vertical layout)

### Generated Note Format
The created markdown file includes:

---
task-list: "My List"
due: 2026-03-15
tags:
  - google-tasks
---

# Task Title

## Notes

Task description/notes from Google Tasks

<html><body><h3>Technical Changes</h3>

File | Changes
-- | --
src/helper/CreateTaskNote.ts | New - Helper functions for note creation and file validation
src/modal/CreateTaskNoteModal.ts | New - Modal for configuring note creation + duplicate handling
src/view/GoogleTaskView.ts | Added "Create Note" button to uncompleted tasks only
styles.css | Added styles for new button, modals, and responsive sidebar


## ScreenShots:


<img width="1120" height="642" alt="Screenshot 2026-03-02 at 4 15 01 AM" src="https://github.com/user-attachments/assets/20c2c2b6-0987-4e78-a4d5-39022b1603bb" />


</body></html> 

### Design Decisions
1. **Only for uncompleted tasks**: The button only appears on tasks in the "Todo" section, as creating notes for completed tasks has limited utility
2. **Default folder**: Notes are saved to `/Tasks` by default to keep them organized, but users can change this
3. **No sync**: Notes are static snapshots - they don't sync back to Google Tasks (keeping it simple and avoiding complexity)
4. **Subtasks excluded**: The button doesn't appear on subtasks to reduce UI clutter
### Testing
- Create note from task with title only
- Create note from task with notes/description
- Create note from task with due date
- Create note in default folder (Tasks)
- Create note in custom folder
- Create note in nested folder (e.g., `Projects/Work`)
- Handle duplicate file names with sequential numbering
- Handle case where a file exists with the folder name
- Verify button only shows on uncompleted tasks
- Verify responsive sidebar layout works when collapsed



